### PR TITLE
Add clusterEnvironment field in enhanced event

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,11 +82,17 @@ func main() {
 
 	engine := exporter.NewEngine(&cfg, &exporter.ChannelBasedReceiverRegistry{MetricsStore: metricsStore})
 	onEvent := engine.OnEvent
-	if len(cfg.ClusterName) != 0 {
+
+	if cfg.ClusterEnvironment != "" || cfg.ClusterName != "" {
+		log.Info().Msgf("ClusterName: %s, ClusterEnvironment: %s", cfg.ClusterName, cfg.ClusterEnvironment)
+
 		onEvent = func(event *kube.EnhancedEvent) {
-			// note that per code this value is not set anywhere on the kubernetes side
-			// https://github.com/kubernetes/apimachinery/blob/v0.22.4/pkg/apis/meta/v1/types.go#L276
-			event.ClusterName = cfg.ClusterName
+			if cfg.ClusterEnvironment != "" {
+				event.ClusterEnvironment = cfg.ClusterEnvironment
+			}
+			if cfg.ClusterName != "" {
+				event.ClusterName = cfg.ClusterName
+			}
 			engine.OnEvent(event)
 		}
 	}

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	MetricsNamePrefix  string                    `yaml:"metricsNamePrefix,omitempty"`
 	OmitLookup         bool                      `yaml:"omitLookup,omitempty"`
 	CacheSize          int                       `yaml:"cacheSize,omitempty"`
+	ClusterEnvironment string                    `yaml:"clusterEnvironment,omitempty"`
 }
 
 func (c *Config) SetDefaults() {

--- a/pkg/kube/event.go
+++ b/pkg/kube/event.go
@@ -10,9 +10,10 @@ import (
 )
 
 type EnhancedEvent struct {
-	corev1.Event   `json:",inline"`
-	ClusterName    string                  `json:"clusterName"`
-	InvolvedObject EnhancedObjectReference `json:"involvedObject"`
+	corev1.Event       `json:",inline"`
+	ClusterName        string                  `json:"clusterName,omitempty"`
+	ClusterEnvironment string                  `json:"clusterEnvironment,omitempty"`
+	InvolvedObject     EnhancedObjectReference `json:"involvedObject"`
 }
 
 // DeDot replaces all dots in the labels and annotations with underscores. This is required for example in the


### PR DESCRIPTION
Many teams who run multiple clusters across different environments and send events to a centralized logging backend, can use a field like clusterEnvironment to create dashboards with filters so that easily look at events from different environments.

Additionally, this change makes `clusterName` and `clusterEnviroment` optional in the output if they are not set.

## Testing Done
<details>
<summary>With clusterName and clusterEnvironment set</summary>

**`config.yaml`**
```
logLevel: info
logFormat: json
clusterName: my-super-local-cluster
clusterEnvironment: dev
route:
  routes:
    - match:
        - receiver: "dump"
receivers:
  - name: "dump"
    stdout: {}
```

**Events**
```
✗ ./kubernetes-event-exporter -kubeconfig ~/.kube/config | jq .
{"level":"info","time":"2024-01-24T20:13:08-05:00","message":"Reading config file config.yaml"}
{"level":"info","time":"2024-01-24T20:13:08-05:00","message":"Starting with config: exporter.Config{LogLevel:\"info\", LogFormat:\"json\", ThrottlePeriod:0, MaxEventAgeSeconds:0, ClusterName:\"my-super-local-cluster\", Namespace:\"\", LeaderElection:kube.LeaderElectionConfig{Enabled:false, LeaderElectionID:\"\"}, Route:exporter.Route{Drop:[]exporter.Rule(nil), Match:[]exporter.Rule(nil), Routes:[]exporter.Route{exporter.Route{Drop:[]exporter.Rule(nil), Match:[]exporter.Rule{exporter.Rule{Labels:map[string]string(nil), Annotations:map[string]string(nil), Message:\"\", APIVersion:\"\", Kind:\"\", Namespace:\"\", Reason:\"\", Type:\"\", MinCount:0, Component:\"\", Host:\"\", Receiver:\"dump\"}}, Routes:[]exporter.Route(nil)}}}, Receivers:[]sinks.ReceiverConfig{sinks.ReceiverConfig{Name:\"dump\", InMemory:(*sinks.InMemoryConfig)(nil), Webhook:(*sinks.WebhookConfig)(nil), File:(*sinks.FileConfig)(nil), Syslog:(*sinks.SyslogConfig)(nil), Stdout:(*sinks.StdoutConfig)(0x1400036ff60), Elasticsearch:(*sinks.ElasticsearchConfig)(nil), Kinesis:(*sinks.KinesisConfig)(nil), Firehose:(*sinks.FirehoseConfig)(nil), OpenSearch:(*sinks.OpenSearchConfig)(nil), Opsgenie:(*sinks.OpsgenieConfig)(nil), Loki:(*sinks.LokiConfig)(nil), SQS:(*sinks.SQSConfig)(nil), SNS:(*sinks.SNSConfig)(nil), Slack:(*sinks.SlackConfig)(nil), Kafka:(*sinks.KafkaConfig)(nil), Pubsub:(*sinks.PubsubConfig)(nil), Opscenter:(*sinks.OpsCenterConfig)(nil), Teams:(*sinks.TeamsConfig)(nil), BigQuery:(*sinks.BigQueryConfig)(nil), EventBridge:(*sinks.EventBridgeConfig)(nil), Pipe:(*sinks.PipeConfig)(nil)}}, KubeQPS:5, KubeBurst:10, MetricsNamePrefix:\"\", OmitLookup:false, CacheSize:1024, ClusterEnvironment:\"dev\"}"}
{"level":"info","time":"2024-01-24T20:13:08-05:00","message":"setting config.maxEventAgeSeconds=5 (default)"}
{"level":"warn","time":"2024-01-24T20:13:08-05:00","message":"metrics name prefix is empty, setting config.metricsNamePrefix='event_exporter_' is recommended"}
{"level":"info","name":"dump","type":"*sinks.Stdout","time":"2024-01-24T20:13:08-05:00","message":"Registering sink"}
{"level":"info","time":"2024-01-24T20:13:08-05:00","message":"ClusterName: my-super-local-cluster, ClusterEnvironment: dev"}
{"level":"info","time":"2024-01-24T20:13:08-05:00","message":"levelinfomsgListening onaddress[::]:2112"}
{"level":"info","time":"2024-01-24T20:13:08-05:00","message":"levelinfomsgTLS is disabled.http2falseaddress[::]:2112"}
{"level":"info","time":"2024-01-24T20:13:08-05:00","message":"leader election disabled"}
{
  "metadata": {
    "name": "coredns-5dd5756b68-96jnz.17ad7204bf626429",
    "namespace": "kube-system",
    "uid": "7af490f4-03cf-4fcb-b19a-592d3cacaa89",
    "resourceVersion": "4612547",
    "creationTimestamp": "2024-01-25T01:13:18Z"
  },
  "reason": "Killing",
  "message": "Stopping container coredns",
  "source": {
    "component": "kubelet",
    "host": "kind-control-plane"
  },
  "firstTimestamp": "2024-01-25T01:13:18Z",
  "lastTimestamp": "2024-01-25T01:13:18Z",
  "count": 1,
  "type": "Normal",
  "eventTime": null,
  "reportingComponent": "kubelet",
  "reportingInstance": "kind-control-plane",
  "clusterName": "my-super-local-cluster",
  "clusterEnvironment": "dev",
  "involvedObject": {
    "kind": "Pod",
    "namespace": "kube-system",
    "name": "coredns-5dd5756b68-96jnz",
    "uid": "9cd9f80e-04cb-4833-a1c2-0d7d47890278",
    "apiVersion": "v1",
    "resourceVersion": "4609091",
    "fieldPath": "spec.containers{coredns}",
    "labels": {
      "k8s-app": "kube-dns",
      "pod-template-hash": "5dd5756b68"
    },
    "ownerReferences": [
      {
        "apiVersion": "apps/v1",
        "kind": "ReplicaSet",
        "name": "coredns-5dd5756b68",
        "uid": "86ca77ef-fce0-4033-99b3-35ee9a45a1d7",
        "controller": true,
        "blockOwnerDeletion": true
      }
    ],
    "deleted": true
  }
}
```

</details>

<details>
<summary>With just clusterName set</summary>
**`config.yaml`**
```
logLevel: info
logFormat: json
clusterName: my-super-local-cluster
route:
  routes:
    - match:
        - receiver: "dump"
receivers:
  - name: "dump"
    stdout: {}
```

**Events**
```
✗ ./kubernetes-event-exporter -kubeconfig ~/.kube/config | jq .
{"level":"info","time":"2024-01-24T20:14:49-05:00","message":"Reading config file config.yaml"}
{"level":"info","time":"2024-01-24T20:14:49-05:00","message":"Starting with config: exporter.Config{LogLevel:\"info\", LogFormat:\"json\", ThrottlePeriod:0, MaxEventAgeSeconds:0, ClusterName:\"my-super-local-cluster\", Namespace:\"\", LeaderElection:kube.LeaderElectionConfig{Enabled:false, LeaderElectionID:\"\"}, Route:exporter.Route{Drop:[]exporter.Rule(nil), Match:[]exporter.Rule(nil), Routes:[]exporter.Route{exporter.Route{Drop:[]exporter.Rule(nil), Match:[]exporter.Rule{exporter.Rule{Labels:map[string]string(nil), Annotations:map[string]string(nil), Message:\"\", APIVersion:\"\", Kind:\"\", Namespace:\"\", Reason:\"\", Type:\"\", MinCount:0, Component:\"\", Host:\"\", Receiver:\"dump\"}}, Routes:[]exporter.Route(nil)}}}, Receivers:[]sinks.ReceiverConfig{sinks.ReceiverConfig{Name:\"dump\", InMemory:(*sinks.InMemoryConfig)(nil), Webhook:(*sinks.WebhookConfig)(nil), File:(*sinks.FileConfig)(nil), Syslog:(*sinks.SyslogConfig)(nil), Stdout:(*sinks.StdoutConfig)(0x1400036fc70), Elasticsearch:(*sinks.ElasticsearchConfig)(nil), Kinesis:(*sinks.KinesisConfig)(nil), Firehose:(*sinks.FirehoseConfig)(nil), OpenSearch:(*sinks.OpenSearchConfig)(nil), Opsgenie:(*sinks.OpsgenieConfig)(nil), Loki:(*sinks.LokiConfig)(nil), SQS:(*sinks.SQSConfig)(nil), SNS:(*sinks.SNSConfig)(nil), Slack:(*sinks.SlackConfig)(nil), Kafka:(*sinks.KafkaConfig)(nil), Pubsub:(*sinks.PubsubConfig)(nil), Opscenter:(*sinks.OpsCenterConfig)(nil), Teams:(*sinks.TeamsConfig)(nil), BigQuery:(*sinks.BigQueryConfig)(nil), EventBridge:(*sinks.EventBridgeConfig)(nil), Pipe:(*sinks.PipeConfig)(nil)}}, KubeQPS:5, KubeBurst:10, MetricsNamePrefix:\"\", OmitLookup:false, CacheSize:1024, ClusterEnvironment:\"\"}"}
{"level":"info","time":"2024-01-24T20:14:49-05:00","message":"setting config.maxEventAgeSeconds=5 (default)"}
{"level":"warn","time":"2024-01-24T20:14:49-05:00","message":"metrics name prefix is empty, setting config.metricsNamePrefix='event_exporter_' is recommended"}
{"level":"info","name":"dump","type":"*sinks.Stdout","time":"2024-01-24T20:14:49-05:00","message":"Registering sink"}
{"level":"info","time":"2024-01-24T20:14:49-05:00","message":"ClusterName: my-super-local-cluster, ClusterEnvironment: "}
{"level":"info","time":"2024-01-24T20:14:49-05:00","message":"levelinfomsgListening onaddress[::]:2112"}
{"level":"info","time":"2024-01-24T20:14:49-05:00","message":"levelinfomsgTLS is disabled.http2falseaddress[::]:2112"}
{"level":"info","time":"2024-01-24T20:14:49-05:00","message":"leader election disabled"}
{
  "metadata": {
    "name": "coredns-5dd5756b68-bs6gh.17ad721c14688ef4",
    "namespace": "kube-system",
    "uid": "d406186d-4faf-4c55-bc96-76c1d78d60d6",
    "resourceVersion": "4612709",
    "creationTimestamp": "2024-01-25T01:14:58Z"
  },
  "reason": "Killing",
  "message": "Stopping container coredns",
  "source": {
    "component": "kubelet",
    "host": "kind-control-plane"
  },
  "firstTimestamp": "2024-01-25T01:14:58Z",
  "lastTimestamp": "2024-01-25T01:14:58Z",
  "count": 1,
  "type": "Normal",
  "eventTime": null,
  "reportingComponent": "kubelet",
  "reportingInstance": "kind-control-plane",
  "clusterName": "my-super-local-cluster",
  "involvedObject": {
    "kind": "Pod",
    "namespace": "kube-system",
    "name": "coredns-5dd5756b68-bs6gh",
    "uid": "8450eaef-ef95-44fe-bc07-95e3c6be1f5f",
    "apiVersion": "v1",
    "resourceVersion": "4611978",
    "fieldPath": "spec.containers{coredns}",
    "labels": {
      "k8s-app": "kube-dns",
      "pod-template-hash": "5dd5756b68"
    },
    "ownerReferences": [
      {
        "apiVersion": "apps/v1",
        "kind": "ReplicaSet",
        "name": "coredns-5dd5756b68",
        "uid": "86ca77ef-fce0-4033-99b3-35ee9a45a1d7",
        "controller": true,
        "blockOwnerDeletion": true
      }
    ],
    "deleted": true
  }
}
```

</details>

<details>

<summary>With just clusterEnvironment set</summary>
**`config.yaml`**
```
logLevel: info
logFormat: json
clusterEnvironment: dev
route:
  routes:
    - match:
        - receiver: "dump"
receivers:
  - name: "dump"
    stdout: {}
```

**Events**
```
✗ ./kubernetes-event-exporter -kubeconfig ~/.kube/config | jq .
{"level":"info","time":"2024-01-24T20:17:01-05:00","message":"Reading config file config.yaml"}
{"level":"info","time":"2024-01-24T20:17:01-05:00","message":"Starting with config: exporter.Config{LogLevel:\"info\", LogFormat:\"json\", ThrottlePeriod:0, MaxEventAgeSeconds:0, ClusterName:\"\", Namespace:\"\", LeaderElection:kube.LeaderElectionConfig{Enabled:false, LeaderElectionID:\"\"}, Route:exporter.Route{Drop:[]exporter.Rule(nil), Match:[]exporter.Rule(nil), Routes:[]exporter.Route{exporter.Route{Drop:[]exporter.Rule(nil), Match:[]exporter.Rule{exporter.Rule{Labels:map[string]string(nil), Annotations:map[string]string(nil), Message:\"\", APIVersion:\"\", Kind:\"\", Namespace:\"\", Reason:\"\", Type:\"\", MinCount:0, Component:\"\", Host:\"\", Receiver:\"dump\"}}, Routes:[]exporter.Route(nil)}}}, Receivers:[]sinks.ReceiverConfig{sinks.ReceiverConfig{Name:\"dump\", InMemory:(*sinks.InMemoryConfig)(nil), Webhook:(*sinks.WebhookConfig)(nil), File:(*sinks.FileConfig)(nil), Syslog:(*sinks.SyslogConfig)(nil), Stdout:(*sinks.StdoutConfig)(0x1400011c4c0), Elasticsearch:(*sinks.ElasticsearchConfig)(nil), Kinesis:(*sinks.KinesisConfig)(nil), Firehose:(*sinks.FirehoseConfig)(nil), OpenSearch:(*sinks.OpenSearchConfig)(nil), Opsgenie:(*sinks.OpsgenieConfig)(nil), Loki:(*sinks.LokiConfig)(nil), SQS:(*sinks.SQSConfig)(nil), SNS:(*sinks.SNSConfig)(nil), Slack:(*sinks.SlackConfig)(nil), Kafka:(*sinks.KafkaConfig)(nil), Pubsub:(*sinks.PubsubConfig)(nil), Opscenter:(*sinks.OpsCenterConfig)(nil), Teams:(*sinks.TeamsConfig)(nil), BigQuery:(*sinks.BigQueryConfig)(nil), EventBridge:(*sinks.EventBridgeConfig)(nil), Pipe:(*sinks.PipeConfig)(nil)}}, KubeQPS:5, KubeBurst:10, MetricsNamePrefix:\"\", OmitLookup:false, CacheSize:1024, ClusterEnvironment:\"dev\"}"}
{"level":"info","time":"2024-01-24T20:17:01-05:00","message":"setting config.maxEventAgeSeconds=5 (default)"}
{"level":"warn","time":"2024-01-24T20:17:01-05:00","message":"metrics name prefix is empty, setting config.metricsNamePrefix='event_exporter_' is recommended"}
{"level":"info","name":"dump","type":"*sinks.Stdout","time":"2024-01-24T20:17:01-05:00","message":"Registering sink"}
{"level":"info","time":"2024-01-24T20:17:01-05:00","message":"ClusterName: , ClusterEnvironment: dev"}
{"level":"info","time":"2024-01-24T20:17:01-05:00","message":"levelinfomsgListening onaddress[::]:2112"}
{"level":"info","time":"2024-01-24T20:17:01-05:00","message":"levelinfomsgTLS is disabled.http2falseaddress[::]:2112"}
{"level":"info","time":"2024-01-24T20:17:01-05:00","message":"leader election disabled"}
{
  "metadata": {
    "name": "coredns-5dd5756b68-7lmbv.17ad723b2bcec172",
    "namespace": "kube-system",
    "uid": "28bdfef1-65a5-49ad-b0bb-617d1960430e",
    "resourceVersion": "4612911",
    "creationTimestamp": "2024-01-25T01:17:12Z"
  },
  "reason": "Killing",
  "message": "Stopping container coredns",
  "source": {
    "component": "kubelet",
    "host": "kind-control-plane"
  },
  "firstTimestamp": "2024-01-25T01:17:12Z",
  "lastTimestamp": "2024-01-25T01:17:12Z",
  "count": 1,
  "type": "Normal",
  "eventTime": null,
  "reportingComponent": "kubelet",
  "reportingInstance": "kind-control-plane",
  "clusterEnvironment": "dev",
  "involvedObject": {
    "kind": "Pod",
    "namespace": "kube-system",
    "name": "coredns-5dd5756b68-7lmbv",
    "uid": "21bd83fd-d0a8-487e-a97f-168ccd83e369",
    "apiVersion": "v1",
    "resourceVersion": "4612552",
    "fieldPath": "spec.containers{coredns}",
    "labels": {
      "k8s-app": "kube-dns",
      "pod-template-hash": "5dd5756b68"
    },
    "ownerReferences": [
      {
        "apiVersion": "apps/v1",
        "kind": "ReplicaSet",
        "name": "coredns-5dd5756b68",
        "uid": "86ca77ef-fce0-4033-99b3-35ee9a45a1d7",
        "controller": true,
        "blockOwnerDeletion": true
      }
    ],
    "deleted": true
  }
}
```
</details>